### PR TITLE
Add support for a TTY-friendly Calendar marker character.

### DIFF
--- a/denote-journal.el
+++ b/denote-journal.el
@@ -114,6 +114,11 @@ journal entry (refer to the `tmr' package on GNU ELPA)."
   :group 'denote-journal
   :type 'hook)
 
+(defcustom denote-journal-terminal-calendar-marker ?*
+  "Character to mark a Denote journal entry in the `calendar` when in terminal mode."
+  :group 'denote-journal
+  :type 'character)
+
 (defun denote-journal-directory ()
   "Make the variable `denote-journal-directory' and its parents."
   (if-let* (((stringp denote-journal-directory))
@@ -308,6 +313,14 @@ file's title.  This has the same meaning as in `denote-link'."
 (defface denote-journal-calendar '((t :box (:line-width (-1 . -1))))
   "Face to mark a Denote journal entry in the `calendar'.")
 
+(defun denote-journal--get-calendar-marker (date)
+  "Return the appropriate marker for DATE.
+If GUI Emacs, return the symbol 'denote-journal-calendar.
+If terminal Emacs, return the character `denote-journal-terminal-calendar-marker'."
+  (if (display-graphic-p)
+      'denote-journal-calendar
+    denote-journal-terminal-calendar-marker))
+
 (defun denote-journal-calendar--file-to-date (file)
   "Convert FILE to calendar date by interpreting its identifier."
   (when-let* ((identifier (denote-retrieve-filename-identifier file))
@@ -348,7 +361,7 @@ file's title.  This has the same meaning as in `denote-link'."
               (dates (delq nil (mapcar #'denote-journal-calendar--file-to-date files))))
     (dolist (date dates)
       (when (calendar-date-is-visible-p date)
-        (calendar-mark-visible-date date 'denote-journal-calendar)))))
+        (calendar-mark-visible-date date (denote-journal--get-calendar-marker date))))))
 
 (defun denote-journal-calendar--date-to-time (calendar-date)
   "Return internal time of `calendar' CALENDAR-DATE.

--- a/denote-journal.el
+++ b/denote-journal.el
@@ -114,11 +114,6 @@ journal entry (refer to the `tmr' package on GNU ELPA)."
   :group 'denote-journal
   :type 'hook)
 
-(defcustom denote-journal-terminal-calendar-marker ?*
-  "Character to mark a Denote journal entry in the `calendar` when in terminal mode."
-  :group 'denote-journal
-  :type 'character)
-
 (defun denote-journal-directory ()
   "Make the variable `denote-journal-directory' and its parents."
   (if-let* (((stringp denote-journal-directory))
@@ -310,16 +305,11 @@ file's title.  This has the same meaning as in `denote-link'."
 
 ;;;; Integration with the `calendar'
 
-(defface denote-journal-calendar '((t :box (:line-width (-1 . -1))))
+(defface denote-journal-calendar
+  '((((supports :box t))
+     :box (:line-width (-1 . -1)))
+    (t :inverse-video t))
   "Face to mark a Denote journal entry in the `calendar'.")
-
-(defun denote-journal--get-calendar-marker (date)
-  "Return the appropriate marker for DATE.
-If GUI Emacs, return the symbol 'denote-journal-calendar.
-If terminal Emacs, return the character `denote-journal-terminal-calendar-marker'."
-  (if (display-graphic-p)
-      'denote-journal-calendar
-    denote-journal-terminal-calendar-marker))
 
 (defun denote-journal-calendar--file-to-date (file)
   "Convert FILE to calendar date by interpreting its identifier."
@@ -361,7 +351,7 @@ If terminal Emacs, return the character `denote-journal-terminal-calendar-marker
               (dates (delq nil (mapcar #'denote-journal-calendar--file-to-date files))))
     (dolist (date dates)
       (when (calendar-date-is-visible-p date)
-        (calendar-mark-visible-date date (denote-journal--get-calendar-marker date))))))
+        (calendar-mark-visible-date date 'denote-journal-calendar)))))
 
 (defun denote-journal-calendar--date-to-time (calendar-date)
   "Return internal time of `calendar' CALENDAR-DATE.


### PR DESCRIPTION
In the current implementation, days with journal entries in the calendar are marked using only the denote-journal-calendar face, which is not visible in terminal Emacs. 
This PR adds a customisable variable, `denote-journal-calendar-tty-marker` and updates the marking logic to insert this marker character after the date in TTY Emacs. 

This would provide a visible hint for terminal users, improving usability and accessibility.