### PR TITLE
Allow nil date in `denote-journal--date-in-interval-p`

### DIFF
--- a/denote-journal.el
+++ b/denote-journal.el
@@ -251,7 +251,7 @@ DATE has the same format as that returned by `denote-valid-date-p'."
   "Return DATE if it is within the INTERVAL else nil.
 INTERVAL is one among the symbols used by `denote-journal-interval'.
 DATE has the same format as that returned by `denote-valid-date-p'."
-  (if-let* ((date (denote-valid-date-p date))
+  (if-let* ((date (or (denote-valid-date-p date) (current-time)))
             (current (current-time))
             (specifiers (pcase interval
                           ('weekly "%Y-%V")


### PR DESCRIPTION
Until recently, one could call `denote-journal-path-to-new-or-existing-entry` with a nil date to use the current time (see for instance https://github.com/protesilaos/denote-journal/blob/3c1f264780dbfd89d483143cd1419f178adc859c/denote-journal.el#L242).

Such use now fails with an error `The date ‘nil’ does not satisfy ‘denote-valid-date-p’`. This PR attempts to fix this by setting the date to the current time if it is nil.