### PR TITLE
Small bug fix

### DIFF
--- a/denote-journal.el
+++ b/denote-journal.el
@@ -302,7 +302,7 @@ DATE has the same format as that returned by `denote-valid-date-p'."
         date))
     (error "The date `%s' does not satisfy `denote-valid-date-p'" date)))
 
-(defun denote-journal--get-entry (date interval)
+(defun denote-journal--get-entry (date &optional interval)
   "Return list of files matching a journal for DATE given INTERVAL.
 INTERVAL is one among the symbols used by `denote-journal-interval'.
 DATE has the same format as that returned by `denote-valid-date-p'."


### PR DESCRIPTION
On calendar, pressing "F" to go the note of the day at point will trigger an error, after tracking it down, it seems like the `denote-journal--get-entry` function is called without passing the interval. 

https://github.com/protesilaos/denote-journal/blob/729beaea78ca6d7a3cf947b2ee003bac5227c3a2/denote-journal.el#L473

---

### Bug reproduction
1. `M-x calendar`
2. Move to a date with a journal note
3. Press `F`

#### The bug
```elisp
Debugger entered--Lisp error: (wrong-number-of-arguments #f(lambda (date interval) [t] "Return list of files matching a journal for DATE given INTERVAL.\nINTERVAL is one among the symbols used by `denote-journal-interval'.\nDATE has the same format as that returned by `denote-valid-date-p'." (let ((denote-directory (denote-journal-directory))) (denote-directory-files (denote-journal--filename-regexp date interval)))) 1)
  denote-journal--get-entry((26805 41057))
  (if date (denote-journal--get-entry date))
  (let* ((date (and t (denote-journal-calendar--date-to-time calendar-date)))) (if date (denote-journal--get-entry date)))
  denote-journal-calendar--date-to-identifier((9 1 2025))
  (and t (denote-journal-calendar--date-to-identifier calendar-date))
  (let* ((files (and t (denote-journal-calendar--date-to-identifier calendar-date))) (file (and files (denote-journal-select-file-prompt files)))) (if file (funcall denote-open-link-function file) (user-error "No Denote journal entry for this date")))
  (if calendar-date (let* ((files (and t (denote-journal-calendar--date-to-identifier calendar-date))) (file (and files (denote-journal-select-file-prompt files)))) (if file (funcall denote-open-link-function file) (user-error "No Denote journal entry for this date"))))
  (let* ((calendar-date (and t (calendar-cursor-to-date)))) (if calendar-date (let* ((files (and t (denote-journal-calendar--date-to-identifier calendar-date))) (file (and files (denote-journal-select-file-prompt files)))) (if file (funcall denote-open-link-function file) (user-error "No Denote journal entry for this date")))))
  denote-journal-calendar-find-file()
  funcall-interactively(denote-journal-calendar-find-file)
  command-execute(denote-journal-calendar-find-file)
```

## EDIT:
TBH, I'm not sure this is the right way to do it, maybe you need to include some `interval` notion in the `denote-journal-calendar-find-file` command and propagate to `denote-journal--get-entry`.